### PR TITLE
Add mr-basic component

### DIFF
--- a/apps/basic-demo/index.html
+++ b/apps/basic-demo/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>mr-basic Demo</title>
+  </head>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/basic-demo/src/main.ts
+++ b/apps/basic-demo/src/main.ts
@@ -1,0 +1,11 @@
+import 'mr-basic/dist/mr-basic.js';
+import { container } from 'tsyringe';
+import { MrBasic, ScaleController, MouseController, DragController } from 'mr-basic';
+
+// Register controllers
+container.register(ScaleController, { useClass: ScaleController });
+container.register(MouseController, { useClass: MouseController });
+container.register(DragController, { useClass: DragController });
+
+const element = container.resolve(MrBasic);
+document.body.appendChild(element);

--- a/packages/mr-basic/package.json
+++ b/packages/mr-basic/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mr-basic",
+  "version": "0.1.0",
+  "description": "A basic web component demonstrating Lit reactive controllers with IoC via tsyringe.",
+  "main": "dist/mr-basic.js",
+  "module": "dist/mr-basic.js",
+  "types": "dist/mr-basic.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "lit": "^3.3.0",
+    "tsyringe": "^4.7.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/mr-basic/src/controllers/DragController.ts
+++ b/packages/mr-basic/src/controllers/DragController.ts
@@ -1,0 +1,48 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { injectable, inject } from 'tsyringe';
+import { MouseController } from './MouseController';
+
+@injectable()
+export class DragController implements ReactiveController {
+  private host!: ReactiveControllerHost & HTMLElement;
+  private dragging = false;
+  private startX = 0;
+  private startY = 0;
+
+  constructor(@inject(MouseController) private mouse: MouseController) {}
+
+  setHost(host: ReactiveControllerHost & HTMLElement) {
+    this.host = host;
+  }
+
+  hostConnected() {
+    this.host.style.position = 'absolute';
+    this.host.addEventListener('pointerdown', this.onDown);
+    window.addEventListener('pointerup', this.onUp);
+    window.addEventListener('pointermove', this.onMove);
+  }
+
+  hostDisconnected() {
+    this.host.removeEventListener('pointerdown', this.onDown);
+    window.removeEventListener('pointerup', this.onUp);
+    window.removeEventListener('pointermove', this.onMove);
+  }
+
+  private onDown = (e: PointerEvent) => {
+    this.dragging = true;
+    this.startX = e.clientX - this.host.offsetLeft;
+    this.startY = e.clientY - this.host.offsetTop;
+  };
+
+  private onUp = () => {
+    this.dragging = false;
+  };
+
+  private onMove = () => {
+    if (!this.dragging) return;
+    const x = this.mouse.x - this.startX;
+    const y = this.mouse.y - this.startY;
+    this.host.style.left = `${x}px`;
+    this.host.style.top = `${y}px`;
+  };
+}

--- a/packages/mr-basic/src/controllers/MouseController.ts
+++ b/packages/mr-basic/src/controllers/MouseController.ts
@@ -1,0 +1,27 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { injectable } from 'tsyringe';
+
+@injectable()
+export class MouseController implements ReactiveController {
+  public x = 0;
+  public y = 0;
+  private host!: ReactiveControllerHost & HTMLElement;
+
+  setHost(host: ReactiveControllerHost & HTMLElement) {
+    this.host = host;
+  }
+
+  hostConnected() {
+    this.host.addEventListener('pointermove', this.onMove);
+  }
+
+  hostDisconnected() {
+    this.host.removeEventListener('pointermove', this.onMove);
+  }
+
+  private onMove = (e: PointerEvent) => {
+    this.x = e.clientX;
+    this.y = e.clientY;
+    this.host.requestUpdate();
+  };
+}

--- a/packages/mr-basic/src/controllers/ScaleController.ts
+++ b/packages/mr-basic/src/controllers/ScaleController.ts
@@ -1,0 +1,34 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { injectable } from 'tsyringe';
+
+@injectable()
+export class ScaleController implements ReactiveController {
+  private host!: ReactiveControllerHost & HTMLElement;
+  public scale = 1;
+
+  setHost(host: ReactiveControllerHost & HTMLElement) {
+    this.host = host;
+  }
+
+  hostConnected() {
+    this.host.addEventListener('wheel', this.onWheel);
+    this.applyScale();
+  }
+
+  hostDisconnected() {
+    this.host.removeEventListener('wheel', this.onWheel);
+  }
+
+  private onWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    this.scale += e.deltaY > 0 ? -0.1 : 0.1;
+    if (this.scale < 0.1) this.scale = 0.1;
+    this.applyScale();
+    this.host.requestUpdate();
+  };
+
+  private applyScale() {
+    this.host.style.transform = `scale(${this.scale})`;
+    this.host.style.transformOrigin = 'top left';
+  }
+}

--- a/packages/mr-basic/src/index.ts
+++ b/packages/mr-basic/src/index.ts
@@ -1,0 +1,1 @@
+export * from './mr-basic';

--- a/packages/mr-basic/src/mr-basic.ts
+++ b/packages/mr-basic/src/mr-basic.ts
@@ -1,0 +1,43 @@
+import 'reflect-metadata';
+import { LitElement, html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { autoInjectable, inject } from 'tsyringe';
+import { ScaleController } from './controllers/ScaleController';
+import { MouseController } from './controllers/MouseController';
+import { DragController } from './controllers/DragController';
+
+@customElement('mr-basic')
+@autoInjectable()
+export class MrBasic extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      width: 150px;
+      height: 150px;
+      background: lightgray;
+      user-select: none;
+      touch-action: none;
+    }
+  `;
+
+  constructor(
+    @inject(ScaleController) private scaleController?: ScaleController,
+    @inject(MouseController) private mouseController?: MouseController,
+    @inject(DragController) private dragController?: DragController
+  ) {
+    super();
+    this.scaleController?.setHost(this);
+    this.mouseController?.setHost(this);
+    this.dragController?.setHost(this);
+
+    this.addController(this.scaleController!);
+    this.addController(this.mouseController!);
+    this.addController(this.dragController!);
+  }
+
+  render() {
+    return html`<slot></slot>`;
+  }
+}
+
+export { ScaleController, MouseController, DragController };

--- a/packages/mr-basic/tsconfig.json
+++ b/packages/mr-basic/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `mr-basic` package with base web component
- implement `ScaleController`, `MouseController`, and `DragController`
- provide simple demo in `apps/basic-demo`

## Testing
- `npx tsc --noEmit` in `packages/mr-basic`
- `npm run build` in `packages/mr-basic`

------
https://chatgpt.com/codex/tasks/task_e_68679a6dbb048322a855fb2dacbb17ab