### PR TITLE
feat: expose animation loop interface

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -190,7 +190,6 @@ export * from "./packages/mr-abstract-components/dist/features/abstractions/IPhy
 export * from "./packages/mr-abstract-components/dist/features/abstractions/ISystemController";
 export * from "./packages/mr-abstract-components/dist/features/abstractions/IVisualObject";
 export * from "./packages/mr-abstract-components/dist/features/abstractions/IVisualObjectConfiguration";
-export * from "./packages/mr-abstract-components/dist/features/animation/AnimationLoop";
 export * from "./packages/mr-abstract-components/dist/features/canvas/ICanvasController";
 export * from "./packages/mr-abstract-components/dist/features/canvas/ICanvasEngine";
 export * from "./packages/mr-abstract-components/dist/features/canvas/IConnectorConfiguration";
@@ -309,7 +308,6 @@ export * from "./packages/mr-web-components/playwright.config";
 export * from "./packages/mr-web-components/test-setup";
 export * from "./packages/mr-web-components/vitest.browser.config";
 export * from "./packages/mr-web-components/vitest.config";
-export * from "./packages/mr-web-components/dist/mr-abstract-components/src/canvas/AnimationLoop";
 export * from "./packages/mr-web-components/dist/mr-web-components/playwright.config";
 export * from "./packages/mr-web-components/dist/mr-web-components/test-setup";
 export * from "./packages/mr-web-components/dist/mr-web-components/vitest.browser.config";

--- a/packages/mr-abstract-components/src/animation/AnimationLoop.ts
+++ b/packages/mr-abstract-components/src/animation/AnimationLoop.ts
@@ -1,0 +1,5 @@
+export interface IAnimationLoop {
+  start(): void;
+  stop(): void;
+  onTick(cb: (dt: number) => void): void;
+}

--- a/packages/mr-abstract-components/src/index.ts
+++ b/packages/mr-abstract-components/src/index.ts
@@ -46,7 +46,6 @@ export * from './abstractions/sceneGraph/node/TransformNode.js';
 export * from './abstractions/sceneGraph/traversal/Traversal.js';
 export * from './abstractions/core/VisualObject.js';
 export * from './abstractions/world/WorldBase.js';
- 
 export * from './core/bootStrap/bootstrap.js';
 export * from './canvas/ICanvasController.js';
 export * from './canvas/IConnectorConfiguration.js';
@@ -79,4 +78,4 @@ export * from './sceneObjects/rope/IRopeVisualConfiguration.js';
 export * from './store/IDatastore.js';
 export * from './core/style/IStyle.js';
 export * from './utils/snap.js';
-
+export * from './animation/AnimationLoop.js';

--- a/packages/mr-web-components/src/RAFLoop.ts
+++ b/packages/mr-web-components/src/RAFLoop.ts
@@ -1,4 +1,4 @@
-import type { IAnimationLoop } from "mr-abstract-components/src/animation/AnimationLoop";
+import type { IAnimationLoop } from "mr-abstract-components";
 
 export class RAFLoop implements IAnimationLoop {
   private last = 0;


### PR DESCRIPTION
## Summary
- add `IAnimationLoop` interface and barrel export
- update `RAFLoop` to import from `mr-abstract-components`
- remove stale AnimationLoop deep exports

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@mr/design-patterns"; No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689670c76f148322a68ff1044a53b266